### PR TITLE
Replace relative pathed requires for inferred node_modules location

### DIFF
--- a/src/Collection.ts
+++ b/src/Collection.ts
@@ -6,7 +6,7 @@ import { TreeNode } from "./TreeNode";
 import { Utils } from "./Utils";
 import { TreeNodeType } from "./TreeNodeType";
 import { LanguageMap } from "./LanguageMap";
-const ViewingDirectionEnum = require('../node_modules/@iiif/vocabulary/dist-commonjs/').ViewingDirection;
+const ViewingDirectionEnum = require('@iiif/vocabulary/dist-commonjs/').ViewingDirection;
 export class Collection extends IIIFResource {
     public items: IIIFResource[] = [];
     private _collections: Collection[] | null = null;

--- a/src/IIIFResource.ts
+++ b/src/IIIFResource.ts
@@ -156,8 +156,8 @@ export class IIIFResource extends ManifestResource {
 }
 
 // https://github.com/ionic-team/ionic-app-scripts/issues/1219#issuecomment-386114424
-const IIIFResourceTypeEnum = require('../node_modules/@iiif/vocabulary/dist-commonjs/').IIIFResourceType;
-const ServiceProfileEnum = require('../node_modules/@iiif/vocabulary/dist-commonjs/').ServiceProfile;
+const IIIFResourceTypeEnum = require('@iiif/vocabulary/dist-commonjs/').IIIFResourceType;
+const ServiceProfileEnum = require('@iiif/vocabulary/dist-commonjs/').ServiceProfile;
 import { TreeNode } from "./TreeNode";
 import { Collection } from "./Collection";
 import { IManifestoOptions } from "./IManifestoOptions";

--- a/src/Manifest.ts
+++ b/src/Manifest.ts
@@ -8,9 +8,9 @@ import { Utils } from "./Utils";
 import { TreeNodeType } from "./TreeNodeType";
 import { Range } from "./Range";
 import { ManifestType, Service } from ".";
-const BehaviorEnum = require('../node_modules/@iiif/vocabulary/dist-commonjs/').Behavior;
-const ServiceProfileEnum = require('../node_modules/@iiif/vocabulary/dist-commonjs/').ServiceProfile;
-const ViewingHintEnum = require('../node_modules/@iiif/vocabulary/dist-commonjs/').ViewingHint;
+const BehaviorEnum = require('@iiif/vocabulary/dist-commonjs/').Behavior;
+const ServiceProfileEnum = require('@iiif/vocabulary/dist-commonjs/').ServiceProfile;
+const ViewingHintEnum = require('@iiif/vocabulary/dist-commonjs/').ViewingHint;
 
 export class Manifest extends IIIFResource {
     public index: number = 0;

--- a/src/ManifestResource.ts
+++ b/src/ManifestResource.ts
@@ -1,5 +1,5 @@
 import { JSONLDResource } from "./JSONLDResource";
-const IIIFResourceTypeEnum = require('../node_modules/@iiif/vocabulary/dist-commonjs/').IIIFResourceType;
+const IIIFResourceTypeEnum = require('@iiif/vocabulary/dist-commonjs/').IIIFResourceType;
 
 export class ManifestResource extends JSONLDResource {
     externalResource: IExternalResource;

--- a/src/Range.ts
+++ b/src/Range.ts
@@ -6,7 +6,7 @@ import { Utils } from "./Utils";
 import { Behavior, ViewingDirection, ViewingHint } from "@iiif/vocabulary";
 import { LanguageMap } from "./LanguageMap";
 import { TreeNodeType } from "./TreeNodeType";
-const BehaviorEnum = require('../node_modules/@iiif/vocabulary/dist-commonjs/').Behavior;
+const BehaviorEnum = require('@iiif/vocabulary/dist-commonjs/').Behavior;
 
 export class Range extends ManifestResource {
     private _ranges: Range[] | null = null;

--- a/src/Sequence.ts
+++ b/src/Sequence.ts
@@ -7,8 +7,8 @@ import { Utils } from "./Utils";
 import { LanguageMap } from "./LanguageMap";
 import { Thumb } from "./Thumb";
 import { Manifest } from "./Manifest";
-const ViewingDirectionEnum = require('../node_modules/@iiif/vocabulary/dist-commonjs/').ViewingDirection;
-const ViewingHintEnum = require('../node_modules/@iiif/vocabulary/dist-commonjs/').ViewingHint;
+const ViewingDirectionEnum = require('@iiif/vocabulary/dist-commonjs/').ViewingDirection;
+const ViewingHintEnum = require('@iiif/vocabulary/dist-commonjs/').ViewingHint;
 export class Sequence extends ManifestResource {
     public items: Canvas[] = [];
     private _thumbnails: Thumbnail[] | null = null;

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -9,7 +9,7 @@ import { TreeNode } from "./TreeNode";
 import { Deserialiser } from "./Serialisation";
 import { MediaType, ServiceProfile } from "@iiif/vocabulary";
 import { IIIFResource } from "./IIIFResource";
-const ServiceProfileEnum = require('../node_modules/@iiif/vocabulary/dist-commonjs/').ServiceProfile;
+const ServiceProfileEnum = require('@iiif/vocabulary/dist-commonjs/').ServiceProfile;
 
 const http = require('http');
 const https = require('https');

--- a/test/tests/aarau.js
+++ b/test/tests/aarau.js
@@ -4,7 +4,7 @@ var expect = require('chai').expect;
 var should = require('chai').should();
 var manifesto = require('../../dist-commonjs/');
 var manifests = require('../fixtures/manifests');
-var ServiceProfile = require('../../node_modules/@iiif/vocabulary/dist-commonjs/').ServiceProfile;
+var ServiceProfile = require('@iiif/vocabulary/dist-commonjs/').ServiceProfile;
 
 var manifest;
 

--- a/test/tests/annotation-list.js
+++ b/test/tests/annotation-list.js
@@ -2,8 +2,8 @@ var expect = require('chai').expect;
 var should = require('chai').should();
 var manifesto = require('../../dist-commonjs/');
 var manifests = require('../fixtures/manifests');
-var AnnotationMotivation = require('../../node_modules/@iiif/vocabulary/dist-commonjs/').AnnotationMotivation;
-var ExternalResourceType = require('../../node_modules/@iiif/vocabulary/dist-commonjs/').ExternalResourceType;
+var AnnotationMotivation = require('@iiif/vocabulary/dist-commonjs/').AnnotationMotivation;
+var ExternalResourceType = require('@iiif/vocabulary/dist-commonjs/').ExternalResourceType;
 
 describe('#loadsAnnotationList', function() {
   var manifest, canvas, annotationList;

--- a/test/tests/biocrats.js
+++ b/test/tests/biocrats.js
@@ -3,9 +3,9 @@ var should = require('chai').should();
 var manifesto = require('../../dist-commonjs/');
 var manifests = require('../fixtures/manifests');
 
-var RenderingFormat = require('../../node_modules/@iiif/vocabulary/dist-commonjs/').RenderingFormat;
-var ServiceProfile = require('../../node_modules/@iiif/vocabulary/dist-commonjs/').ServiceProfile;
-var ViewingHint = require('../../node_modules/@iiif/vocabulary/dist-commonjs/').ViewingHint;
+var RenderingFormat = require('@iiif/vocabulary/dist-commonjs/').RenderingFormat;
+var ServiceProfile = require('@iiif/vocabulary/dist-commonjs/').ServiceProfile;
+var ViewingHint = require('@iiif/vocabulary/dist-commonjs/').ViewingHint;
 
 var manifest, sequence;
 

--- a/test/tests/chemistdruggist.js
+++ b/test/tests/chemistdruggist.js
@@ -4,7 +4,7 @@ var expect = require('chai').expect;
 var should = require('chai').should();
 var manifesto = require('../../dist-commonjs/');
 var manifests = require('../fixtures/manifests');
-var IIIFResourceType = require('../../node_modules/@iiif/vocabulary/dist-commonjs/').IIIFResourceType;
+var IIIFResourceType = require('@iiif/vocabulary/dist-commonjs/').IIIFResourceType;
 
 var collection, manifest, firstCollection, secondCollection, secondManifest, thirdManifest;
 

--- a/test/tests/correspondance.js
+++ b/test/tests/correspondance.js
@@ -4,7 +4,7 @@ var expect = require('chai').expect;
 var should = require('chai').should();
 var manifesto = require('../../dist-commonjs/');
 var manifests = require('../fixtures/manifests');
-var ServiceProfile = require('../../node_modules/@iiif/vocabulary/dist-commonjs/').ServiceProfile;
+var ServiceProfile = require('@iiif/vocabulary/dist-commonjs/').ServiceProfile;
 
 var manifest, sequence, canvas, imageService;
 

--- a/test/tests/get-manifest-behavior.js
+++ b/test/tests/get-manifest-behavior.js
@@ -2,7 +2,7 @@ var expect = require('chai').expect;
 var should = require('chai').should();
 var manifesto = require('../../dist-commonjs/');
 var manifests = require('../fixtures/manifests');
-var Behavior = require('../../node_modules/@iiif/vocabulary/dist-commonjs/').Behavior;
+var Behavior = require('@iiif/vocabulary/dist-commonjs/').Behavior;
 
 var manifest;
 

--- a/test/tests/nested.js
+++ b/test/tests/nested.js
@@ -4,7 +4,7 @@ var expect = require('chai').expect;
 var should = require('chai').should();
 var manifesto = require('../../dist-commonjs/');
 var manifests = require('../fixtures/manifests');
-var IIIFResourceType = require('../../node_modules/@iiif/vocabulary/dist-commonjs/').IIIFResourceType;
+var IIIFResourceType = require('@iiif/vocabulary/dist-commonjs/').IIIFResourceType;
 
 var collection, manifest, firstCollection, secondCollection;
 

--- a/test/tests/pres3-collection.js
+++ b/test/tests/pres3-collection.js
@@ -2,8 +2,8 @@ var expect = require('chai').expect;
 var should = require('chai').should();
 var manifesto = require('../../dist-commonjs/');
 var manifests = require('../fixtures/manifests');
-var IIIFResourceType = require('../../node_modules/@iiif/vocabulary/dist-commonjs/').IIIFResourceType;
-var ViewingDirection = require('../../node_modules/@iiif/vocabulary/dist-commonjs/').ViewingDirection;
+var IIIFResourceType = require('@iiif/vocabulary/dist-commonjs/').IIIFResourceType;
+var ViewingDirection = require('@iiif/vocabulary/dist-commonjs/').ViewingDirection;
 
 var collection;
 

--- a/test/tests/presentation2-paging.js
+++ b/test/tests/presentation2-paging.js
@@ -2,7 +2,7 @@ var expect = require('chai').expect;
 var should = require('chai').should();
 var manifesto = require('../../dist-commonjs/');
 var manifests = require('../fixtures/manifests');
-var ViewingHint = require('../../node_modules/@iiif/vocabulary/dist-commonjs/').ViewingHint;
+var ViewingHint = require('@iiif/vocabulary/dist-commonjs/').ViewingHint;
 
 var manifest;
 

--- a/test/tests/presentation3-paging.js
+++ b/test/tests/presentation3-paging.js
@@ -2,7 +2,7 @@ var expect = require('chai').expect;
 var should = require('chai').should();
 var manifesto = require('../../dist-commonjs/');
 var manifests = require('../fixtures/manifests');
-var Behavior = require('../../node_modules/@iiif/vocabulary/dist-commonjs/').Behavior;
+var Behavior = require('@iiif/vocabulary/dist-commonjs/').Behavior;
 
 var manifest;
 

--- a/test/tests/qatarrighttoleft.js
+++ b/test/tests/qatarrighttoleft.js
@@ -3,7 +3,7 @@ var expect = require('chai').expect;
 var should = require('chai').should();
 var manifesto = require('../../dist-commonjs/');
 var manifests = require('../fixtures/manifests');
-var ViewingDirection = require('../../node_modules/@iiif/vocabulary/dist-commonjs/').ViewingDirection;
+var ViewingDirection = require('@iiif/vocabulary/dist-commonjs/').ViewingDirection;
 
 var manifest, sequence;
 

--- a/test/tests/scroll.js
+++ b/test/tests/scroll.js
@@ -2,7 +2,7 @@ var expect = require('chai').expect;
 var should = require('chai').should();
 var manifesto = require('../../dist-commonjs/');
 var manifests = require('../fixtures/manifests');
-var ServiceProfile = require('../../node_modules/@iiif/vocabulary/dist-commonjs/').ServiceProfile;
+var ServiceProfile = require('@iiif/vocabulary/dist-commonjs/').ServiceProfile;
 
 var manifest, sequence;
 

--- a/test/tests/storyofwellcome.js
+++ b/test/tests/storyofwellcome.js
@@ -3,7 +3,7 @@ var expect = require('chai').expect;
 var should = require('chai').should();
 var manifesto = require('../../dist-commonjs/');
 var manifests = require('../fixtures/manifests');
-var ServiceProfile = require('../../node_modules/@iiif/vocabulary/dist-commonjs/').ServiceProfile;
+var ServiceProfile = require('@iiif/vocabulary/dist-commonjs/').ServiceProfile;
 
 var manifest, sequence, element;
 

--- a/test/tests/witnesstopeter.js
+++ b/test/tests/witnesstopeter.js
@@ -3,7 +3,7 @@ var expect = require('chai').expect;
 var should = require('chai').should();
 var manifesto = require('../../dist-commonjs/');
 var manifests = require('../fixtures/manifests');
-var ServiceProfile = require('../../node_modules/@iiif/vocabulary/dist-commonjs/').ServiceProfile;
+var ServiceProfile = require('@iiif/vocabulary/dist-commonjs/').ServiceProfile;
 
 var manifest;
 


### PR DESCRIPTION
While perhaps not the most es6 elegant solution. This should resolve the relative path resolution issues while still maintaining compatibility where commonjs is needed.